### PR TITLE
fix calculating permissions overwrites

### DIFF
--- a/permissions.go
+++ b/permissions.go
@@ -60,6 +60,11 @@ func ApplyChannelPermissions(perms int64, guildID int64, overwrites []discordgo.
 		return perms
 	}
 
+	// If user is admin or owner, overrides dont apply
+	if perms == AllPermissions {
+		return perms
+	}
+
 	// Apply chanel overwrites
 
 	// Apply @everyone overrides from the channel.


### PR DESCRIPTION
Hi!

The `ApplyChannelPermissions` func was not taking into consideration if the user is the owner of the guild or an administrator. When that's the case, overrides do not apply to that user.
Not taking this into consideration, was making the `CalculatePermissions` return incorrect values. 
This was also causing some YAGPDB commands not to work properly on some cases because they only run when the bot has some specific perms.