### PR TITLE
additional work on adding guild member avatar

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -309,6 +309,10 @@ func (ms *MemberState) DgoMember() *discordgo.Member {
 		m.JoinedAt = ms.Member.JoinedAt
 	}
 
+	if m.Avatar == "" {
+		m.Avatar = m.User.Avatar
+	}
+
 	return m
 }
 

--- a/interface.go
+++ b/interface.go
@@ -309,10 +309,6 @@ func (ms *MemberState) DgoMember() *discordgo.Member {
 		m.JoinedAt = ms.Member.JoinedAt
 	}
 
-	if m.Avatar == "" {
-		m.Avatar = m.User.Avatar
-	}
-
 	return m
 }
 

--- a/interface.go
+++ b/interface.go
@@ -240,6 +240,7 @@ type MemberFields struct {
 	JoinedAt discordgo.Timestamp
 	Roles    []int64
 	Nick     string
+	Avatar   string
 }
 
 type PresenceStatus int32
@@ -282,6 +283,7 @@ func MemberStateFromMember(member *discordgo.Member) *MemberState {
 			JoinedAt: member.JoinedAt,
 			Roles:    member.Roles,
 			Nick:     member.Nick,
+			Avatar:   member.Avatar,
 		},
 		Presence: nil,
 	}
@@ -298,6 +300,7 @@ func (ms *MemberState) DgoMember() *discordgo.Member {
 		GuildID:  ms.GuildID,
 		JoinedAt: ms.Member.JoinedAt,
 		Nick:     ms.Member.Nick,
+		Avatar:   ms.Member.Avatar,
 		Roles:    ms.Member.Roles,
 		User:     &ms.User,
 	}


### PR DESCRIPTION
Besides making changes to the member struct in discordgo, `MemberFields` in dstate also requires an addition. This PR makes the necessary changes to reflect the additions in botlabs-gg/discordgo@581bfc8 and to show the member avatar successfully.